### PR TITLE
Add data structure dependencies and webpack resolution of filenames

### DIFF
--- a/app/js/components/App.jsx
+++ b/app/js/components/App.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Footer from './Footer.jsx';
-import AddTodo from '../containers/AddTodo.jsx';
-import VisibleTodoList from '../containers/VisibleTodoList.jsx';
+import Footer from './Footer';
+import AddTodo from '../containers/AddTodo';
+import VisibleTodoList from '../containers/VisibleTodoList';
 
 import style from './App.css';
 import examplePic from '../../img/Example.png';

--- a/app/js/components/Footer.jsx
+++ b/app/js/components/Footer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import FilterLink from '../containers/FilterLink.jsx';
+import FilterLink from '../containers/FilterLink';
 
 const Footer = () => (
     <p>

--- a/app/js/components/TodoList.jsx
+++ b/app/js/components/TodoList.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import Todo from './Todo.jsx';
+import Todo from './Todo';
 
 const TodoList = ({ todos, onTodoClick }) => (
     <ul>

--- a/app/js/containers/FilterLink.jsx
+++ b/app/js/containers/FilterLink.jsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { setVisibilityFilter } from '../actions';
-import Link from '../components/Link.jsx';
+import Link from '../components/Link';
 
 const mapStateToProps = (state, ownProps) => {
     return {

--- a/app/js/containers/VisibleTodoList.jsx
+++ b/app/js/containers/VisibleTodoList.jsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { toggleTodo } from '../actions';
-import TodoList from '../components/TodoList.jsx';
+import TodoList from '../components/TodoList';
 
 const getVisibleTodos = (todos, filter) => {
     let visible = todos;

--- a/app/js/main.jsx
+++ b/app/js/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import todoApp from './reducers';
-import App from './components/App.jsx';
+import App from './components/App';
 
 import '../css/main.css';
 

--- a/app/js/reducers/index.js
+++ b/app/js/reducers/index.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
-import todos from './todos.js';
-import visibilityFilter from './visibilityFilter.js';
+import todos from './todos';
+import visibilityFilter from './visibilityFilter';
 
 const todoApp = combineReducers({
     todos,

--- a/config/webpack.shared.js
+++ b/config/webpack.shared.js
@@ -19,6 +19,9 @@ module.exports = function extendConfig(override, isDev) {
             filename: 'js/bundle.js'
         },
         plugins: [],
+        resolve: {
+            extensions: ['', '.js', '.jsx']
+        },
         module: {
             loaders: [
                 {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "qiime-studio-backend",
+  "name": "qiime-studio-frontend",
   "version": "0.0.1",
   "description": "A web-based interface for QIIME 2.",
   "author": "QIIME 2 Development Team",
@@ -34,6 +34,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "chai": "^3.5.0",
+    "chai-immutable": "^1.5.4",
     "css-loader": "^0.23.1",
     "eslint": "^2.6.0",
     "eslint-config-airbnb": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "webpack --config config/webpack.prod.config.js"
   },
   "dependencies": {
+    "immutable": "^3.7.6",
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
     "react-redux": "^4.4.1",


### PR DESCRIPTION
Adding a few potential dependencies to the build before we get too far in that it would be a hassle to implement them. Also allows the resolution of filenames through the shared webpack config file in order to remove the requirement of adding file extensions to imports.