### PR TITLE
Add Immutable data structures to lint exceptions

### DIFF
--- a/config/eslint.yaml
+++ b/config/eslint.yaml
@@ -11,3 +11,9 @@ rules:
     # There are edge cases such as (x) => { foo: [] } which are syntactically
     # ambiguous, does it return an object or is that a labeled block?
     arrow-body-style: [off, always]
+    # Immutable.js breaks linting without this rule
+    # usage will require import { Map as ImmutableMap, List as ImmutableList }
+    # as allowing just Map will also exempt the built-in JS Map object
+    new-cap:
+      - 1
+      - capIsNewExceptions: [ImmutableList, ImmutableMap]


### PR DESCRIPTION
Using Map() and List() from Immutable will break the linter as they don't use `new` before their declarations. Added exceptions to custom names of ImmutableMap and ImmutableList, as excepting Map alone would also override checking on the built in JS Map().

Immutable usage changes from 
```javascript
import { Map, List } from 'immutable';
```
to
```javascript
import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
```